### PR TITLE
Added logging to Rmq, and cleaned up namespacing.

### DIFF
--- a/src/Qualm.Rmq.Tests/DispatcherTests.cs
+++ b/src/Qualm.Rmq.Tests/DispatcherTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Qualm.Rmq;
+using Moq;
+using Qualm.Queuing;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Qualm.Rmq.Tests
+{
+  public class DispatcherTests
+  {
+    private readonly ILogger _logger;
+    private readonly ITestOutputHelper _output;
+
+    public DispatcherTests(ITestOutputHelper output)
+    {
+      _output = output;
+      _logger = _output.BuildLogger();
+    }
+    [Fact]
+    public void DependencyInjection_Success()
+    {
+      var services = new ServiceCollection();
+
+      services.AddSingleton<ITestOutputHelper>(_output);
+      services.AddScoped<ILogger>(f => f.GetService<ITestOutputHelper>().BuildLogger());
+      services.AddScoped<ILogger<RmqDispatcher>>(f => 
+        f.GetService<ITestOutputHelper>().BuildLoggerFor<RmqDispatcher>());
+      services.AddSingleton<IQueueMessageMapperRegistry>((s) => new Mock<IQueueMessageMapperRegistry>().Object);
+      services.AddSingleton<IQueueMessageMapperFactory>((s => new Mock<IQueueMessageMapperFactory>().Object));
+      services.AddRmqQueueing(new RmqConnectionDetails{ });
+
+      var provider = services.BuildServiceProvider();
+      var dispatcher = provider.GetService<RmqDispatcher>();
+
+      Assert.NotNull(dispatcher);
+    }
+  }
+}

--- a/src/Qualm.Rmq.Tests/Qualm.Rmq.Tests.csproj
+++ b/src/Qualm.Rmq.Tests/Qualm.Rmq.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Divergic.Logging.Xunit" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Qualm\Qualm.csproj" />
+    <ProjectReference Include="..\Qualm.Rmq\Qualm.Rmq.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Qualm.Rmq/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Qualm.Rmq/DependencyInjection/IServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Qualm.Queuing;
 
-namespace Qualm.Rmq.DependancyInjection
+namespace Qualm.Rmq
 {
     public static class IServiceCollectionExtensions
     {

--- a/src/Qualm.Rmq/DependencyInjection/RmqQueueingOptions.cs
+++ b/src/Qualm.Rmq/DependencyInjection/RmqQueueingOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Qualm.Rmq.DependancyInjection
+﻿namespace Qualm.Rmq
 {
     public class RmqQueueingOptions
     {

--- a/src/Qualm.sln
+++ b/src/Qualm.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Qualm.AspNetCore.Swagger", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Qualm.Rmq", "Qualm.Rmq\Qualm.Rmq.csproj", "{312ED2C8-887E-40FB-ABB7-96DF51F74AD2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Qualm.Rmq.Tests", "Qualm.Rmq.Tests\Qualm.Rmq.Tests.csproj", "{70643796-CE81-4BA7-9DC5-597B61AAB0F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{312ED2C8-887E-40FB-ABB7-96DF51F74AD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{312ED2C8-887E-40FB-ABB7-96DF51F74AD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{312ED2C8-887E-40FB-ABB7-96DF51F74AD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70643796-CE81-4BA7-9DC5-597B61AAB0F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70643796-CE81-4BA7-9DC5-597B61AAB0F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70643796-CE81-4BA7-9DC5-597B61AAB0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70643796-CE81-4BA7-9DC5-597B61AAB0F1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Qualm/Commands/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Qualm/Commands/DependencyInjection/IServiceCollectionExtensions.cs
@@ -16,13 +16,5 @@ namespace Qualm.Commands.DependencyInjection
 
             return registry;
         }
-
-        public static IServiceCollection AddRmq(
-            this IServiceCollection services,
-            ServiceLifetime lifetime = ServiceLifetime.Scoped)
-        {
-            
-            return services;            
-        }
     }
 }

--- a/src/Qualm/Commands/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Qualm/Commands/DependencyInjection/IServiceCollectionExtensions.cs
@@ -16,5 +16,13 @@ namespace Qualm.Commands.DependencyInjection
 
             return registry;
         }
+
+        public static IServiceCollection AddRmq(
+            this IServiceCollection services,
+            ServiceLifetime lifetime = ServiceLifetime.Scoped)
+        {
+            
+            return services;            
+        }
     }
 }

--- a/src/Qualm/Qualm.csproj
+++ b/src/Qualm/Qualm.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
   </ItemGroup>

--- a/src/Qualm/Queuing/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Qualm/Queuing/DependencyInjection/IServiceCollectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-namespace Qualm.Queuing.DependancyInjection
+namespace Qualm.Queuing
 {
     public static class IServiceCollectionExtensions
     {

--- a/src/Qualm/Queuing/DependencyInjection/QueueMessageMapperFactory.cs
+++ b/src/Qualm/Queuing/DependencyInjection/QueueMessageMapperFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Qualm.Queuing.DependancyInjection
+namespace Qualm.Queuing
 {
     public class QueueMessageMapperFactory : IQueueMessageMapperFactory
     {

--- a/src/Qualm/Queuing/DependencyInjection/QueueMessageMapperRegistry.cs
+++ b/src/Qualm/Queuing/DependencyInjection/QueueMessageMapperRegistry.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Qualm.Queuing.DependancyInjection
+namespace Qualm.Queuing
 {
     public class QueueMessageMapperRegistry : IQueueMessageMapperRegistry
     {


### PR DESCRIPTION
The RmqDispatcher is now injected an ILogger<T>, which logs the name and id of the command before and after execution. Added unit tests for this.

Also cleaned up namespacing. Dependency was misspelled sometimes (not always), and some extensions now have less specific namespacing.