### PR TITLE
This enables explode parameter for when applying ArrayInQueryParameters filter

### DIFF
--- a/src/Qualm.AspNetCore.Swagger/ArrayInQueryParametersFilter.cs
+++ b/src/Qualm.AspNetCore.Swagger/ArrayInQueryParametersFilter.cs
@@ -18,6 +18,8 @@ namespace Qualm.AspNetCore.Swagger
                 {
                     parameter.Style = ParameterStyle.Form;
                 }
+
+                parameter.Explode = true;
             }
         }
     }


### PR DESCRIPTION
As is the ArrayInQueryParametersFilter fixes a problem preventing autorest from auto generating C# clients when a query has an array parameter. However, it also breaks the array binding for the query model. A user will be prompted to enter multiple items from the swagger interface. When it is bound though you will get a comma delimited string or worse an exception for non-string arrays. This is because the fix adds the querystring for the array as `array=string1,string2`. The existence of the array parameter is solved by the current ArrayInQueryParametersFilter. This PR enables the `explode` parameter in swagger so that we get the following correct querystring `array=string1&array=string2`. 